### PR TITLE
DependencyInjection duplication

### DIFF
--- a/Compentio.SourceMapper.Generator/Compentio.SourceMapper.csproj
+++ b/Compentio.SourceMapper.Generator/Compentio.SourceMapper.csproj
@@ -9,11 +9,11 @@
     <Product>SourceMapper</Product>
     <Authors>Aleksander Parchomenko</Authors>
     <PackageProjectUrl>https://alekshura.github.io/SourceMapper/</PackageProjectUrl>
-    <AssemblyVersion>2.0.0.2</AssemblyVersion>
-    <FileVersion>2.0.0.2</FileVersion>
+    <AssemblyVersion>2.0.0.3</AssemblyVersion>
+    <FileVersion>2.0.0.3</FileVersion>
     <PackageId>Compentio.SourceMapper</PackageId>
     <GenerateRepositoryUrlAttribute>true</GenerateRepositoryUrlAttribute>
-    <Version>2.0.0.2</Version>
+    <Version>2.0.0.3</Version>
     <Description>Code generator for mappings based on attributes defined in interfaces or abstrat classes. It is based on .NetCore Source Generators engine and generates classes for mappers during build time of you project.</Description>
     <Copyright>Copyright (c) @alekshura Compentio 2021</Copyright>
     <RepositoryUrl>https://github.com/alekshura/SourceMapper</RepositoryUrl>

--- a/Compentio.SourceMapper.Generator/Generators/CodeSourceGenerator.cs
+++ b/Compentio.SourceMapper.Generator/Generators/CodeSourceGenerator.cs
@@ -54,6 +54,8 @@ namespace Compentio.SourceMapper.Generators
                 return;
             }
 
+            if (!_sourcesMetadata.Mappers.Any()) return;
+
             var result = processorStrategy.GenerateCode(_sourcesMetadata);
 
             context.AddSource($"{_sourcesMetadata.DependencyInjection.DependencyInjectionClassName}.cs", SourceText.From(result.GeneratedCode, Encoding.UTF8));


### PR DESCRIPTION
If domain project has mappers and dependency injection extension file generated, then in project, which reference domain project, dependency injection extension file should not be duplicated.